### PR TITLE
Add OpenGraphConsumer plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -92,6 +92,8 @@ listings here do not imply endorsement by the Known project team in any way.
 * [Markdown](https://github.com/mapkyca/IdnoMarkdown) - Adds Markdown support for status and blog posts, 
     by [Marcus Povey](https://www.marcus-povey.co.uk)
 
+* [OpenGraph Link Rendering](https://github.com/hank/IdnoOpenGraphConsumer) - Automatically convert raw hyperlinks in content to OpenGraph "cards", similar to Twitter Summary Cards.
+    by [Erik Gregg](https://www.jointsecurityarea.org)
 
 ## Submissions
 


### PR DESCRIPTION
I created a plugin to use OpenGraph metadata from raw hyperlinks in posts to create nice "cards" inline, like you see here:

https://www.jointsecurityarea.org/2015/im-messing-around-with-opengraph-
Repo: https://github.com/hank/IdnoOpenGraphConsumer/
